### PR TITLE
Fix three other broken links to Code of Conduct

### DIFF
--- a/COMPONENTS_REQUEST_POLICY.md
+++ b/COMPONENTS_REQUEST_POLICY.md
@@ -58,7 +58,7 @@ or some other means.
 ## Useful Links
 - [Contributing](CONTRIBUTING.md)
 - [Filing an Issue](ISSUE_TEMPLATE.md)
-- [Code of Conduct](CONDUCT.md)
+- [Code of Conduct](CODE_OF_CONDUCT.md)
 - [Stack Overflow](https://www.stackoverflow.com/questions/tagged/material-components) (external site)
 - [Material.io](https://www.material.io) (external site)
 - [Material Design Guidelines](https://material.google.com) (external site)

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -21,7 +21,7 @@ For usage questions: ask on [Stack  Overflow](http://stackoverflow.com/questions
 ## Useful Links
 - [Contributing](CONTRIBUTING.md)
 - [Components Request Policy](COMPONENTS_REQUEST_POLICY.md)
-- [Code of Conduct](CONDUCT.md)
+- [Code of Conduct](CODE_OF_CONDUCT.md)
 - [Stack Overflow](https://www.stackoverflow.com/questions/tagged/material-components) (external site)
 - [Material.io](https://www.material.io) (external site)
 - [Material Design Guidelines](https://material.google.com) (external site)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repo contains all common documentation for Material Components projects acr
 - [Contributing](CONTRIBUTING.md)
 - [Filing an Issue](ISSUE_TEMPLATE.md)
 - [Components Request Policy](COMPONENTS_REQUEST_POLICY.md)
-- [Code of Conduct](CONDUCT.md)
+- [Code of Conduct](CODE_OF_CONDUCT.md)
 - [Stack Overflow](https://stackoverflow.com/questions/tagged/material-components) (external site)
 - [Material.io](https://www.material.io) (external site)
 - [Material Design Guidelines](https://material.google.com) (external site)


### PR DESCRIPTION
I should have fixed these three broken links in my [previous commit](https://github.com/material-components/material-components/commit/f5bc89e913bb10aac45e4d5201bafa24fb927f77) where I fixed two links which had the same incorrect URL but I somehow missed them.